### PR TITLE
Boka tid ist för Sök tid i menyrad på hemsida

### DIFF
--- a/web/src/routes/(hp)/c/[url]/+page.svelte
+++ b/web/src/routes/(hp)/c/[url]/+page.svelte
@@ -171,7 +171,7 @@
                                 color="theme-primary"
                                 size="md"
                                 href="https://{organization.url}.kaddio.com/booking"
-                                >Sök tid</KdLinkButton
+                                >Boka tid</KdLinkButton
                             >
                         </div>
                     {/if}


### PR DESCRIPTION
För att få in ordet "boka" på hemsidan. 
Knapp på hemsidan i menyraden heter Boka tid ist för Sök tid. Övriga länkknappar till bokningen heter Sök tid. 