### PR TITLE
Använd systemfont och ta bort Open sans google font

### DIFF
--- a/web/src/app.html
+++ b/web/src/app.html
@@ -9,13 +9,6 @@
             crossorigin="anonymous"
         ></script>
 
-        <link rel="preconnect" href="https://fonts.googleapis.com" />
-        <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-        <link
-            href="https://fonts.googleapis.com/css2?family=Open+Sans:wght@400..700&display=swap"
-            rel="stylesheet"
-        />
-
         <meta
             name="google-site-verification"
             content="5LWZdYLxmJVde6qc-5NAvjZ8ImfvN1-rv_XKGL6uFzM"

--- a/web/tailwind.config.cjs
+++ b/web/tailwind.config.cjs
@@ -93,8 +93,7 @@ module.exports = {
         },
 
         fontFamily: {
-            // sans: ['Inter var', ...defaultTheme.fontFamily.sans],
-            sans: ['Open Sans', ...defaultTheme.fontFamily.sans]
+            sans: ['ui-sans-serif', 'system-ui']
         }
     },
     plugins: [require('@tailwindcss/forms'), require('@tailwindcss/typography')]


### PR DESCRIPTION
Att ta bort google fonts har störst påverkan av alla prestandaåtgärder på hemsidan.

Jag är av uppfattningen efter att jag läst och lyssnat på mycket kring detta att hastighet (googles metric via bl.a. https://pagespeed.web.dev) är det enskilt viktigaste mätvärdet som sökmotorer går på, samt en förutsättning för flera andra mätvärden (First Contentful Paint, Speed Index, Largest Contentful Paint, osv)

Vi har nu möjlighet att placera oss i toppen av alla konkurrenter när det gäller prestanda på hemsidan (säljsidan)

apple.com - apple kör bara med systemfont på sin hemsida.
google.com - kör med systemfont på sin söksida.

Vår ambition i seo-arbetet är att vi ska bli bäst bland de vi konkurrerar med, med de mätvärden vi kan påverka (vi kan inte ha samma google ads-budget som bokadirekt t.ex.) men vi kan få snabbare sida.

obs. font awesome visas inte heller men det beror bara på vår review-maskin.