### PR TITLE
Remove header contents

### DIFF
--- a/web/src/routes/(hp)/en/(feature)/communication/+page.svelte
+++ b/web/src/routes/(hp)/en/(feature)/communication/+page.svelte
@@ -59,7 +59,7 @@
 </ModuleSectionWithImage>
 
 <ModuleOverviewFeaturesSection>
-	<span slot="pre">Contents</span>
+	
 	<span slot="title">This is Kaddio Chat and Video</span>
 	<span slot="body"> With Kaddio Chat and Video you communicate securely with clients and colleagues. 
 		<br>Everything in Kaddio is encrypted.

--- a/web/src/routes/(hp)/en/(feature)/communication/+page.svelte
+++ b/web/src/routes/(hp)/en/(feature)/communication/+page.svelte
@@ -4,10 +4,10 @@
     import ModuleOverviewFeaturesSection from "$components/moduleOverviewFeaturesSection.svelte";
     import ModuleOverviewFeature from "$components/moduleOverviewFeature.svelte";
     import ModuleOverviewFeaturesSegment from "$components/moduleOverviewFeaturesSegment.svelte";
-    import Quote from "$components/quote.svelte";
-    import QuotesSection from "$components/quotesSection.svelte";
+    
+	import QuotesSection from "$components/quotesSection.svelte";
     import StatsSectionEn from '$components/statsSectionEn.svelte';
-    import StatsSectionPart from "$components/statsSectionPart.svelte";
+    
 	import QuoteEnJimmy from '$components/quoteEnJimmy.svelte';
 	import QuoteEnJonas from '$components/quoteEnJonas.svelte';
 	import QuoteEnRamzi from '$components/quoteEnRamzi.svelte';

--- a/web/src/routes/(hp)/en/(feature)/invoicing/+page.svelte
+++ b/web/src/routes/(hp)/en/(feature)/invoicing/+page.svelte
@@ -50,7 +50,7 @@
 </ModuleSectionWithImage>
 
 <ModuleOverviewFeaturesSection>
-	<span slot="pre">Contents</span>
+	
 	<span slot="title">This is Kaddio Invoicing</span>
 	<span slot="body">With Kaddio Invoicing you easily send invoices from bookings or medical record entries. 
 		Handle everything in the same system and spend more time on your clients.

--- a/web/src/routes/(hp)/en/(feature)/online-booking/+page.svelte
+++ b/web/src/routes/(hp)/en/(feature)/online-booking/+page.svelte
@@ -56,7 +56,7 @@
 </ModuleSectionWithImage>
 
 <ModuleOverviewFeaturesSection>
-	<span slot="pre">Contents</span>
+	
 	<span slot="title">This is Kaddio Booking</span>
 	<span slot="body">Kaddio Booking helps you plan all activities of the organization in an 
 		efficient and comprehensable way, whether you are part of a 

--- a/web/src/routes/(hp)/sv/(feature)/fakturering/+page.svelte
+++ b/web/src/routes/(hp)/sv/(feature)/fakturering/+page.svelte
@@ -67,7 +67,7 @@
 </ModuleSectionWithImage>
 
 <ModuleOverviewFeaturesSection>
-	<span slot="pre">Innehåll</span>
+	
 	<span slot="title">Detta är Kaddio Fakturering</span>
 	<span slot="body">Med Kaddio Fakturering skickar du enkelt fakturor utifrån bokningar eller journalanteckningar. Hantera allt i samma system och få mer tid till dina klienter.</span>
 

--- a/web/src/routes/(hp)/sv/(feature)/fakturering/+page.svelte
+++ b/web/src/routes/(hp)/sv/(feature)/fakturering/+page.svelte
@@ -1,23 +1,14 @@
 <script>
-	import Qa from "$components/qa.svelte";
-	import ModuleFeature from "$components/moduleFeature.svelte";
-	import ModuleSection from "$components/moduleSection.svelte";
-	import FaqSection from "$components/faqSection.svelte";
+	
     import ModuleSectionWithImage from "$components/moduleSectionWithImage.svelte";
     import ModuleFeatureWithIcon from "$components/moduleFeatureWithIcon.svelte";
-    import ModuleFeaturesSection from "$components/moduleOverviewFeaturesSection.svelte";
+    
     import ModuleOverviewFeaturesSection from "$components/moduleOverviewFeaturesSection.svelte";
     import ModuleOverviewFeature from "$components/moduleOverviewFeature.svelte";
     import ModuleOverviewFeaturesSegment from "$components/moduleOverviewFeaturesSegment.svelte";
-    import ProductFeatureImageOnLeft from "$components/productFeatureImageOnLeft.svelte";
-    import Quote from "$components/quote.svelte";
+    
     import QuotesSection from "$components/quotesSection.svelte";
-    import ProductPricingSection from "$components/productPricingSection.svelte";
-    import StatsSection from "$components/statsSection.svelte";
-    import StatsSectionPart from "$components/statsSectionPart.svelte";
-    import StatsSectionWithText from "$components/statsSectionWithText.svelte";
-    import StatsSectionWithTextPart from "$components/statsSectionWithTextPart.svelte";
-	import SalesSection from "$components/salesSection.svelte";
+    
 	import QuoteSvAmanda from "$components/quote-sv-amanda.svelte";
 	import QuoteSvJimmy from "$components/quote-sv-jimmy.svelte";
 	import QuoteSvJonas from "$components/quote-sv-jonas.svelte";

--- a/web/src/routes/(hp)/sv/(feature)/journalsystem/+page.svelte
+++ b/web/src/routes/(hp)/sv/(feature)/journalsystem/+page.svelte
@@ -4,26 +4,20 @@
     import ModuleSectionWithImage from "$components/moduleSectionWithImage.svelte";
     import ModuleFeatureWithIcon from "$components/moduleFeatureWithIcon.svelte";
 	export let data;
-	import ModuleFeaturesSection from "$components/moduleOverviewFeaturesSection.svelte";
+	
     import ModuleOverviewFeaturesSection from "$components/moduleOverviewFeaturesSection.svelte";
     import ModuleOverviewFeature from "$components/moduleOverviewFeature.svelte";
     import ModuleOverviewFeaturesSegment from "$components/moduleOverviewFeaturesSegment.svelte";
-    import ProductFeatureImageOnLeft from "$components/productFeatureImageOnLeft.svelte";
-    import Quote from "$components/quote.svelte";
+   
     import QuotesSection from "$components/quotesSection.svelte";
-    import ProductPricingSection from "$components/productPricingSection.svelte";
-    import StatsSection from "$components/statsSection.svelte";
-    import StatsSectionPart from "$components/statsSectionPart.svelte";
-    import StatsSectionWithText from "$components/statsSectionWithText.svelte";
-    import StatsSectionWithTextPart from "$components/statsSectionWithTextPart.svelte";
-	import SalesSection from "$components/salesSection.svelte";
+    
 	import QuoteSvAmanda from "$components/quote-sv-amanda.svelte";
 	import QuoteSvJimmy from "$components/quote-sv-jimmy.svelte";
 	import QuoteSvJonas from "$components/quote-sv-jonas.svelte";
-	import QuoteSvKim from "$components/quote-sv-kim.svelte";
+	
 	import QuoteSvRamzi from "$components/quote-sv-ramzi.svelte";
 	import QuoteSvSofia from "$components/quote-sv-sofia.svelte";
-	import QuoteSvUlrika from "$components/quote-sv-ulrika.svelte";
+	
 	import ContactDanielSv from "$components/contactDanielSv.svelte";
 	import PricesSv from "$components/pricesSv.svelte";
 	import StatsSectionSv from "$components/statsSectionSv.svelte";

--- a/web/src/routes/(hp)/sv/(feature)/kommunikation/+page.svelte
+++ b/web/src/routes/(hp)/sv/(feature)/kommunikation/+page.svelte
@@ -69,7 +69,7 @@
 </ModuleSectionWithImage>
 
 <ModuleOverviewFeaturesSection>
-	<span slot="pre">Innehåll</span>
+	
 	<span slot="title">Detta är Kaddio Chat och Video</span>
 	<span slot="body">Med Kaddio Chat och Video kommunicerar du säkert med klienter och kollegor. 
 		<br>Allt i Kaddio är krypterat.</span>

--- a/web/src/routes/(hp)/sv/(feature)/kommunikation/+page.svelte
+++ b/web/src/routes/(hp)/sv/(feature)/kommunikation/+page.svelte
@@ -1,28 +1,23 @@
 <script>
-    import Qa from '$components/qa.svelte';
-    import FaqSection from '$components/faqSection.svelte';
+    
     import ModuleSectionWithImage from '$components/moduleSectionWithImage.svelte';
     import ModuleFeatureWithIcon from '$components/moduleFeatureWithIcon.svelte';
-    import ModuleFeaturesSection from "$components/moduleOverviewFeaturesSection.svelte";
+    
     import ModuleOverviewFeaturesSection from "$components/moduleOverviewFeaturesSection.svelte";
     import ModuleOverviewFeature from "$components/moduleOverviewFeature.svelte";
     import ModuleOverviewFeaturesSegment from "$components/moduleOverviewFeaturesSegment.svelte";
-    import ProductFeatureImageOnLeft from "$components/productFeatureImageOnLeft.svelte";
-    import Quote from "$components/quote.svelte";
+  
     import QuotesSection from "$components/quotesSection.svelte";
-    import ProductPricingSection from "$components/productPricingSection.svelte";
+   
     import StatsSection from "$components/statsSection.svelte";
     import StatsSectionPart from "$components/statsSectionPart.svelte";
-    import StatsSectionWithText from "$components/statsSectionWithText.svelte";
-    import StatsSectionWithTextPart from "$components/statsSectionWithTextPart.svelte";
-    import SalesSection from "$components/salesSection.svelte";
-    import QuoteSvAmanda from '$components/quote-sv-amanda.svelte';
+   
 	import QuoteSvJimmy from '$components/quote-sv-jimmy.svelte';
 	import QuoteSvJonas from '$components/quote-sv-jonas.svelte';
-	import QuoteSvKim from '$components/quote-sv-kim.svelte';
+	
 	import QuoteSvRamzi from '$components/quote-sv-ramzi.svelte';
 	import QuoteSvSofia from '$components/quote-sv-sofia.svelte';
-	import QuoteSvUlrika from '$components/quote-sv-ulrika.svelte';
+	
 	import ContactDanielSv from '$components/contactDanielSv.svelte';
 	import PricesSv from '$components/pricesSv.svelte';
 </script>

--- a/web/src/routes/(hp)/sv/(feature)/onlinebokning/+page.svelte
+++ b/web/src/routes/(hp)/sv/(feature)/onlinebokning/+page.svelte
@@ -1,23 +1,15 @@
 <script>
-	import Qa from "$components/qa.svelte";
-	import ModuleFeature from "$components/moduleFeature.svelte";
-	import ModuleSection from "$components/moduleSection.svelte";
-	import FaqSection from "$components/faqSection.svelte";
+	
     import ModuleSectionWithImage from "$components/moduleSectionWithImage.svelte";
     import ModuleFeatureWithIcon from "$components/moduleFeatureWithIcon.svelte";
-    import ModuleFeaturesSection from "$components/moduleOverviewFeaturesSection.svelte";
+  
     import ModuleOverviewFeaturesSection from "$components/moduleOverviewFeaturesSection.svelte";
     import ModuleOverviewFeature from "$components/moduleOverviewFeature.svelte";
     import ModuleOverviewFeaturesSegment from "$components/moduleOverviewFeaturesSegment.svelte";
-    import ProductFeatureImageOnLeft from "$components/productFeatureImageOnLeft.svelte";
-    import Quote from "$components/quote.svelte";
+    
     import QuotesSection from "$components/quotesSection.svelte";
     import PricesSv from "$components/pricesSv.svelte";
-    import StatsSection from "$components/statsSection.svelte";
-    import StatsSectionPart from "$components/statsSectionPart.svelte";
-    import StatsSectionWithText from "$components/statsSectionWithText.svelte";
-    import StatsSectionWithTextPart from "$components/statsSectionWithTextPart.svelte";
-	import SalesSection from "$components/salesSection.svelte";
+   
 	import ContactDanielSv from "$components/contactDanielSv.svelte";
 	import QuoteSvAmanda from "$components/quote-sv-amanda.svelte";
 	import QuoteSvJimmy from "$components/quote-sv-jimmy.svelte";

--- a/web/src/routes/(hp)/sv/(feature)/onlinebokning/+page.svelte
+++ b/web/src/routes/(hp)/sv/(feature)/onlinebokning/+page.svelte
@@ -63,7 +63,7 @@
 </ModuleSectionWithImage>
 
 <ModuleOverviewFeaturesSection>
-	<span slot="pre">Innehåll</span>
+	
 	<span slot="title">Detta är Kaddio Bokning</span>
 	<span slot="body">Med Kaddio Bokning planerar du organisationens verksamhet effektivt och överskådligt, oavsett om du är del av ett stort företag eller egenföretagare.</span>
 


### PR DESCRIPTION
Har tagit bort lilla rubriken Innehåll/Contents ovanför punktistorna på SE och EN.

Har också städat bort import av oanvända Components på tjänstesidorna på SE och EN.
